### PR TITLE
FDP-2909: Fixed issue that caused the entity page of an Artistic Work…

### DIFF
--- a/themes/duke/templates/individual--dukeart-artistic-work.ftl
+++ b/themes/duke/templates/individual--dukeart-artistic-work.ftl
@@ -38,13 +38,12 @@
       <#assign link = propertyGroups.pullProperty("http://www.w3.org/2006/vcard/ns#hasURL","http://www.w3.org/2006/vcard/ns#URL")!>
       <#if link?has_content && link.statements?has_content>
         <#assign linkStatement = link.statements[0]>
-        <#assign linkAnchor = linkStatement.label>
         <#assign linkUrl = linkStatement.url>
       </#if>
       <#if linkUrl??>
         <#assign linkText>
-            <#if linkAnchor??>${linkAnchor}<#t>
-              <#else>${linkUrl}<#t>
+            <#if linkStatement.label??>${linkAnchor}<#t>
+            <#else>${linkUrl}<#t>
             </#if>
         </#assign>
         <div class="webpage" role="listitem">


### PR DESCRIPTION
… with a URL but no associated link label to break.