### PR TITLE
re-arrange SPARQL variables so they match example and do not try to r…

### DIFF
--- a/src/edu/duke/oit/vivo/webapp/search/documentBuilding/PersonArtisticEventsFields.java
+++ b/src/edu/duke/oit/vivo/webapp/search/documentBuilding/PersonArtisticEventsFields.java
@@ -55,7 +55,7 @@ public class PersonArtisticEventsFields extends DukeContextNodeFields {
           + "  ?personUri a foaf:Person. \n" 
           + "  ?personUri event:isAgentIn ?event . \n"
           + "  ?event a event:Event. \n"
-          + "  ?eventLabel rdfs:label ?label . \n"
+          + "  ?event rdfs:label ?eventLabel . \n"
           + "  OPTIONAL { ?event dukeart:venue ?venue } \n"
           + "  OPTIONAL { ?event core:description ?description } \n"   
           + "  FILTER(?personUri =  ?uri) \n"


### PR DESCRIPTION
…etrieve erroneous records (and cause GC overhead limit error)