### PR TITLE
re-arrange SPARQL variables in artistic events indexer

### DIFF
--- a/src/edu/duke/oit/vivo/webapp/search/documentBuilding/PersonArtisticEventsFields.java
+++ b/src/edu/duke/oit/vivo/webapp/search/documentBuilding/PersonArtisticEventsFields.java
@@ -55,7 +55,7 @@ public class PersonArtisticEventsFields extends DukeContextNodeFields {
           + "  ?personUri a foaf:Person. \n" 
           + "  ?personUri event:isAgentIn ?event . \n"
           + "  ?event a event:Event. \n"
-          + "  ?eventLabel rdfs:label ?label . \n"
+          + "  ?event rdfs:label ?eventLabel . \n"
           + "  OPTIONAL { ?event dukeart:venue ?venue } \n"
           + "  OPTIONAL { ?event core:description ?description } \n"   
           + "  FILTER(?personUri =  ?uri) \n"


### PR DESCRIPTION
I believe this will fix the GC overhead limit reached problem that was preventing a full reindex.