### PR TITLE
FDP-3241: add rdfs:label to Software type

### DIFF
--- a/rdf/tbox/filegraph/duke_extension.owl
+++ b/rdf/tbox/filegraph/duke_extension.owl
@@ -499,6 +499,7 @@
   </owl:ObjectProperty>
 
   <rdf:Description rdf:about="http://vivoweb.org/ontology/core#Software">
+    <rdfs:label xml:lang="en-US">Software</rdfs:label>
     <rdfs:subClassOf rdf:resource="http://purl.org/ontology/bibo/Document"/>
   </rdf:Description>
 


### PR DESCRIPTION
Needed to add this to vivo ontology to make it show up in profile manager