### PR TITLE
FDP-3475: remove references to ajax visualization

### DIFF
--- a/productMods/WEB-INF/web.xml
+++ b/productMods/WEB-INF/web.xml
@@ -1181,17 +1181,7 @@
     <servlet-name>ShortURLVisualizationController</servlet-name>
     <url-pattern>/vis/*</url-pattern>
   </servlet-mapping>
-
-   <servlet>
-    <servlet-name>AjaxVisualizationController</servlet-name>
-    <servlet-class>edu.cornell.mannlib.vitro.webapp.controller.visualization.AjaxVisualizationController</servlet-class>
-  </servlet>
-
-  <servlet-mapping>
-    <servlet-name>AjaxVisualizationController</servlet-name>
-    <url-pattern>/visualizationAjax</url-pattern>
-  </servlet-mapping>
-
+  
   <servlet>
     <servlet-name>DataVisualizationController</servlet-name>
     <servlet-class>edu.cornell.mannlib.vitro.webapp.controller.visualization.DataVisualizationController</servlet-class>

--- a/themes/duke/templates/individual-visualizationFoafPerson.ftl
+++ b/themes/duke/templates/individual-visualizationFoafPerson.ftl
@@ -31,7 +31,6 @@
                           '<script type="text/javascript" src="${urls.base}/js/visualization/sparkline.js"></script>')}           
 
             <script type="text/javascript">
-                var visualizationUrl = '${urls.base}/visualizationAjax?uri=${individual.uri?url}';
                 var infoIconSrc = '${urls.images}/iconInfo.png';
             </script>
 


### PR DESCRIPTION
thought I'd try taking it out entirely - I can't seem to get any data to show up on my local vivo (to test), so this would be an "acceptance first" deploy